### PR TITLE
Improvements while working on AsnaGo replacement.

### DIFF
--- a/css/barcodes.css
+++ b/css/barcodes.css
@@ -33,8 +33,24 @@
     background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" stroke="%23000" stroke-linecap="round" stroke-linejoin="round" fill="%23fff" fill-rule="evenodd"><path d="M.2501 2.5L.25.2501 2.75.25M17.7499 2.5L17.75.2501 15.25.25m-14.9999 15L.25 17.4999l2.5.0001m12.75-.0001l2.2499.0001.0001-2.5" fill="none" stroke-linecap="square" stroke-linejoin="miter" stroke-width=".5"/><path d="M1 8.7501h12.3855L17 8.75" fill="red" stroke="red"/></svg>');
     background-repeat: no-repeat;
     background-size: 100% 100%;
-    width:100%;
+    width: 100%;
 }
+
+.dds-field-barcode-video-frame:focus {
+    scroll-margin-top: 0px; /* Used by scrollIntoView function */
+    outline: none;
+}
+
+/*
+    For websites with ASPX pages and absolute positioned elements, use the following style (cascading the default style - the one with background-image above -).
+
+    .dds-field-barcode-video-frame {
+        position: absolute;
+        left:0px;
+        top: 50%;
+        transform: translateY(-50%);
+    }
+*/
 
 .dds-field-barcode-video-containter {
     display: flex;

--- a/js/barcode-detection/barcode-field.js
+++ b/js/barcode-detection/barcode-field.js
@@ -172,8 +172,13 @@ class Barcodes {
 
     static async decodeFromVideoDevice(codeReader, selectedDeviceId, videoElement, form, targetInput ) {
         return await codeReader.decodeFromVideoDevice(selectedDeviceId, videoElement, (result, error, controls) => {
-            if ( result ) {
-                targetInput.setAttribute('value', result.text);
+            if (result) {
+                let scanText = result.text;
+                const maxLength = targetInput.getAttribute('maxlength');
+                if (maxLength && scanText.length > maxLength) {
+                    scanText = scanText.substring(0, scanText);
+                }
+                targetInput.setAttribute('value', scanText);
                 const audio = new Audio('/lib/asna-expo/audio/barcode-identified-alarm.mp3');
                 audio.play();
                 Barcodes.scanEnd(controls, form);
@@ -202,6 +207,7 @@ class Barcodes {
 
         const scanFrame = document.createElement('div');
         scanFrame.className = 'dds-field-barcode-video-frame';
+        scanFrame.tabIndex = '0'; // Make it focusable (so that dds-field-barcode-video-frame:focus can be applied.)
 
         const scanContainer = document.createElement('div');
         scanContainer.className = 'dds-field-barcode-video-containter';
@@ -224,6 +230,7 @@ class Barcodes {
         }
         else {
             form.appendChild(scanFrame);
+            scanFrame.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
 
         const codeReader = Barcodes.createCodeReader(hintFormats);


### PR DESCRIPTION
1. If input element has 'maxlength' attribute, truncate code before setting the value to the element.
2. For Mobile devices in particular, there may be scrolling active. Force display video frame into view and use focus styles to position correctly.
